### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/mnsoftdev/69d9ef8e-85ee-4231-a3a4-380f86bbeb6b/d1a66383-c735-47b3-b7fa-43a1b879ae16/_apis/work/boardbadge/b0a240c4-b977-478d-80dc-04b8809c7ecb)](https://dev.azure.com/mnsoftdev/69d9ef8e-85ee-4231-a3a4-380f86bbeb6b/_boards/board/t/d1a66383-c735-47b3-b7fa-43a1b879ae16/Microsoft.RequirementCategory)
 # 100DaysBootcampPython


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#57](https://dev.azure.com/mnsoftdev/69d9ef8e-85ee-4231-a3a4-380f86bbeb6b/_workitems/edit/57). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.